### PR TITLE
Use meson 0.54.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,22 +30,6 @@ RUN pip3 install meson
 ADD https://github.com/ninja-build/ninja/releases/download/v1.6.0/ninja-linux.zip /tmp
 RUN unzip /tmp/ninja-linux.zip -d /usr/local/bin
 
-# Template-GLib
-ADD https://github.com/chergert/template-glib/archive/3.25.92.tar.gz /tmp
-RUN tar zxf /tmp/3.25.92.tar.gz -C /tmp
-WORKDIR /tmp/template-glib-3.25.92
-RUN meson setup --prefix=/usr _build
-RUN meson compile -C _build && meson install -C _build
-
-# Valum
-ADD https://github.com/valum-framework/valum/archive/v0.3.13.tar.gz /tmp
-RUN tar zxf /tmp/v0.3.13.tar.gz -C /tmp
-WORKDIR /tmp/valum-0.3.13
-RUN meson setup --prefix=/usr --buildtype=release _build
-RUN meson compile -C _build && meson install -C _build
-RUN echo /usr/lib/x86_64-linux-gnu/vsgi-0.3/servers | tee /etc/ld.so.conf.d/valum-x86_64.conf >/dev/null
-RUN ldconfig
-
 WORKDIR /icd
 ADD . .
 RUN meson setup --prefix=/usr --sysconfdir=/etc --buildtype=release _build

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,23 +34,23 @@ RUN unzip /tmp/ninja-linux.zip -d /usr/local/bin
 ADD https://github.com/chergert/template-glib/archive/3.25.92.tar.gz /tmp
 RUN tar zxf /tmp/3.25.92.tar.gz -C /tmp
 WORKDIR /tmp/template-glib-3.25.92
-RUN meson --prefix=/usr _build
-RUN ninja -C _build && ninja -C _build install
+RUN meson setup --prefix=/usr _build
+RUN meson compile -C _build && meson install -C _build
 
 # Valum
 ADD https://github.com/valum-framework/valum/archive/v0.3.13.tar.gz /tmp
 RUN tar zxf /tmp/v0.3.13.tar.gz -C /tmp
 WORKDIR /tmp/valum-0.3.13
-RUN meson --prefix=/usr --buildtype=release _build
-RUN ninja -C _build && ninja -C _build install
+RUN meson setup --prefix=/usr --buildtype=release _build
+RUN meson compile -C _build && meson install -C _build
 RUN echo /usr/lib/x86_64-linux-gnu/vsgi-0.3/servers | tee /etc/ld.so.conf.d/valum-x86_64.conf >/dev/null
 RUN ldconfig
 
 WORKDIR /icd
 ADD . .
-RUN meson --prefix=/usr --sysconfdir=/etc --buildtype=release _build
+RUN meson setup --prefix=/usr --sysconfdir=/etc --buildtype=release _build
 RUN meson configure -Denable-tests=false _build
-RUN ninja -C _build && ninja -C _build install
+RUN meson compile -C _build && meson install -C _build
 
 CMD ["/usr/bin/icd", "--config", "/etc/icd/icd.conf"]
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('icd', [ 'c', 'vala' ],
           license: 'GPL3+',
           version: '0.1.0',
-    meson_version: '>= 0.40.1',
+    meson_version: '>= 0.54.0',
   default_options: [
                      'c_std=gnu11',
                      'warning_level=2',

--- a/subprojects/template-glib.wrap
+++ b/subprojects/template-glib.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory=template-glib
-url=https://github.com/chergert/template-glib.git
+url= https://github.com/GNOME/template-glib.git
 revision=3.26.0


### PR DESCRIPTION
Shaved some Docker instructions updated to use new commands provided in Meson 0.54.0 as well as set minimum, changed `template-glib` subproject wrap to point to the GNOME version of the dependency because old link pointed to a 404 page with no repository, should be more reliable this time.